### PR TITLE
fix setConfSetting for non-integer values

### DIFF
--- a/Example.py
+++ b/Example.py
@@ -19,8 +19,8 @@ t = qKLib.Tomography()
 # Step 2. Set up Configurations
 # import conf file
 t.importConf('ExampleFiles/conf.txt')
-# or set the conf settings directly or with the helper
-t.setConfSetting('DoAccidentalCorrection', 1)
+# or set the conf settings using the conf property
+t.conf['DoAccidentalCorrection'] =  1
 
 # Step 3. Run Tomography on The data
 # import data file

--- a/src/QuantumTomography/TomoClass.py
+++ b/src/QuantumTomography/TomoClass.py
@@ -108,6 +108,8 @@ class Tomography():
                 valC = 1
             elif (val.lower() == "no" or val.lower() == "false"):
                 valC = 0
+        else:
+            valC = val
         self.conf[setting] = valC
 
     """


### PR DESCRIPTION
Currently `setConfSetting` will not work if the user tries to set a value that is not a string.
This patch fixes that.

Edit: I'll also note it may be the case that the eval based functionality in this library doesn't work with Python 3.13, although I'm not entirely sure, it's just the only explanation I have for some behaviour I've observed. Not relevant to this request though, just a heads up.

Edit2: Just saw the function is deprecated, I got the wrong idea that it was required from `Example.py`, I'll update it to use the dict setting approach.