### PR TITLE
Fix numpy array assignment deprication

### DIFF
--- a/src/QuantumTomography/TomoClass.py
+++ b/src/QuantumTomography/TomoClass.py
@@ -750,6 +750,7 @@ class Tomography:
 
         coincidences = np.real(coincidences)
         coincidences = coincidences.flatten()
+        accidentals = accidentals.flatten()
 
         final_tvals = leastsq(
             maxlike_fitness,
@@ -812,6 +813,7 @@ class Tomography:
 
         coincidences = np.real(coincidences)
         coincidences = coincidences.flatten()
+        accidentals = accidentals.flatten()
 
         bet = self.conf["Beta"]
         if bet > 0:


### PR DESCRIPTION
This addresses a deprecation in array assignment introduced in numpy 1.2.5, actually removed between 2.3.3 and 2.5. Fixes #49. 